### PR TITLE
Fix typo errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,19 +33,17 @@ This schedule will be continually updated with links as registration opens. Chec
 - **Sep 27, 2017**   St. Louis, MO @ [StrangeLoop](https://www.eventbrite.com/e/mozilla-developer-roadshow-presents-what-makes-the-web-work-tickets-37377977537)
 - **Oct 04, 2017**   Springfield, MO @ [SGF Web Devs](https://www.meetup.com/SGF-Web-Devs/events/243148230/)
 - **Oct 13, 2017**  San Francisco, CA @ [Mozilla](https://www.eventbrite.com/e/mozilla-developer-roadshow-presents-women-in-webvr-san-francisco-tickets-37432501620)
-- **Oct 14,2017** Vancouver, BC @ [DevFest Vancouver](https://devfestvancouver.firebaseapp.com/)
+- **Oct 14, 2017** Vancouver, BC @ [DevFest Vancouver](https://devfestvancouver.firebaseapp.com/)
 - **Oct 24, 2017**   Budapest, Hungary @ JSConf Budapest
 - **Nov 06, 2017**   Berlin, Germany @ [beyond tellerrand berlin](https://beyondtellerrand.com/events/berlin-2017/side-events/mozilla-roadshow)
 - **Nov 11, 2017**   Orlando, FL @ [DevFest Florida](https://devfestflorida.org/)
 - **Nov15, 2017**    Hamburg, Germany @ [SinnerSchrader](https://www.meetup.com/MuniCSS-finest/events/243276897/)
 - **Nov 16, 2017**   Tulsa, OK @ [Tech on Tap](https://www.meetup.com/RHTTech-on-Tap/events/242288624/)
 - **Dec 05, 2017**   Monterrey, Mexico @ Softtek
-- **Dec 07, 2017**   Guadalajara, Mexico @Hacker Garage
+- **Dec 07, 2017**   Guadalajara, Mexico @ Hacker Garage
 - **Dec  09, 2017**  Mexico City, Mexico @ Near Soft
 
-Cities will be listed and updated accordingly
-Materials from the events will also be archived
-Read the full blog post on Hacks: mzl.la/devroadshow
+Cities will be listed and updated accordingly. Materials from the events will also be archived. Read the full blog post on [Hacks](https://mzl.la/devroadshow).
 
 
 ## Past Events

--- a/index.html
+++ b/index.html
@@ -34,7 +34,7 @@ help support Mozilla.
     <link rel="apple-touch-icon" type="image/png" sizes="180x180" href="assets/apple-touch-icon-180x180.png">
     <link rel="icon" type="image/png" sizes="196x196" href="assets/favicon-196x196.png">
     <link rel="shortcut icon" href="assets/favicon.ico">
-    <title>2017 Dev Roadshow</title>
+    <title>2017 Developer Roadshow</title>
     <meta name="description" content="Developer Roadshow website for Mozilla">
     <meta name="author" content="Moz Dev Roadshow">
 
@@ -68,12 +68,12 @@ help support Mozilla.
           <li><strong>Oct 14, 2017</strong>: Vancouver, BC @ <a href="https://devfestvancouver.firebaseapp.com/">DevFest Vancouver</a></li>
           <li><strong>Oct 24, 2017</strong>: Budapest, Hungary @ <a href="http://jsconfbp.com/">JSConf Budapest</a></li>
           <li><strong>Nov 03, 2017</strong>: Hamburg, Germany @ SinnerSchrader</li>
-          <li><strong>Nov 06, 2017</strong>: Berlin, Germany @<a href="https://beyondtellerrand.com/events/berlin-2017/side-events/mozilla-roadshow">beyond tellerrand berlin</a></li>
-          <li><strong>Nov 11, 2017</strong>: Orlando, FL @<a href="https://devfestflorida.org/">DevFest Florida</a></li>
-          <li><strong>Nov 15, 2017</strong>: Munich, Germany @<a href="https://www.meetup.com/MuniCSS-finest/events/243276897/">SinnerSchrader</a></li>
+          <li><strong>Nov 06, 2017</strong>: Berlin, Germany @ <a href="https://beyondtellerrand.com/events/berlin-2017/side-events/mozilla-roadshow">beyond tellerrand berlin</a></li>
+          <li><strong>Nov 11, 2017</strong>: Orlando, FL @ <a href="https://devfestflorida.org/">DevFest Florida</a></li>
+          <li><strong>Nov 15, 2017</strong>: Munich, Germany @ <a href="https://www.meetup.com/MuniCSS-finest/events/243276897/">SinnerSchrader</a></li>
           <li><strong>Nov 16, 2017</strong>: Tulsa, OK @ <a href="https://www.meetup.com/RHTTech-on-Tap/events/242288624/">Tech on Tap</a></li>
           <li><strong>Dec 05, 2017</strong>: Monterrey, Mexico @ Softtek</li>
-          <li><strong>Dec 07, 2017</strong>: Guadalajara, Mexico @Hacker Garage</li>
+          <li><strong>Dec 07, 2017</strong>: Guadalajara, Mexico @ Hacker Garage</li>
           <li><strong>Dec 09, 2017</strong>: Mexico City, Mexico @ Near Soft</li>
         
 >>>>>>> 3037ce659cf01d9ed39bf82cee6354e8824fa229

--- a/index.html
+++ b/index.html
@@ -75,8 +75,6 @@ help support Mozilla.
           <li><strong>Dec 05, 2017</strong>: Monterrey, Mexico @ Softtek</li>
           <li><strong>Dec 07, 2017</strong>: Guadalajara, Mexico @ Hacker Garage</li>
           <li><strong>Dec 09, 2017</strong>: Mexico City, Mexico @ Near Soft</li>
-        
->>>>>>> 3037ce659cf01d9ed39bf82cee6354e8824fa229
         </ul>
       </section>
       <section>


### PR DESCRIPTION
Update sentences and hyperlink follow Markdown syntax.